### PR TITLE
ingester: standardize tree names across origins

### DIFF
--- a/Dockerfile.ingester
+++ b/Dockerfile.ingester
@@ -9,6 +9,7 @@ RUN git clone https://github.com/kernelci/kcidb.git && \
     pip install -e .
 
 COPY ingester/ingester.py /app/ingester.py
+COPY data/trees.yml /app/trees.yml
 
 CMD ["python", "/app/ingester.py", "--spool-dir", "/app/spool"]
 

--- a/data/trees.yml
+++ b/data/trees.yml
@@ -1,0 +1,150 @@
+trees:
+  aaptel:
+    url: "https://github.com/aaptel/linux.git"
+
+  amlogic:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/amlogic/linux.git"
+
+  android:
+    url: 'https://android.googlesource.com/kernel/common'
+
+  ardb:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/ardb/linux.git"
+
+  arm64:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git"
+
+  arnd:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/arnd/playground.git"
+
+  broonie-misc:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/broonie/misc.git"
+
+  broonie-regmap:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/broonie/regmap.git"
+
+  broonie-regulator:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/broonie/regulator.git"
+
+  broonie-sound:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/broonie/sound.git"
+
+  broonie-spi:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/broonie/spi.git"
+
+  chrome-platform:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/chrome-platform/linux.git"
+
+  chromiumos:
+    url: "https://chromium.googlesource.com/chromiumos/third_party/kernel.git"
+
+  cip:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/cip/linux-cip.git"
+
+  clk:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/clk/linux.git"
+
+  collabora-chromeos-kernel:
+    url: 'https://gitlab.collabora.com/google/chromeos-kernel.git'
+
+  efi:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/efi/efi.git"
+
+  hyperv:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/hyperv/linux.git"
+
+  kernelci:
+    url: "https://github.com/kernelci/linux.git"
+
+  khilman:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/khilman/linux.git"
+
+  krzysztof:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/krzk/linux.git"
+
+  kselftest:
+    url: 'https://git.kernel.org/pub/scm/linux/kernel/git/shuah/linux-kselftest.git'
+
+  lee-backlight:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/lee/backlight.git"
+
+  lee-mfd:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/lee/mfd.git"
+
+  linusw:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/linusw/linux-gpio.git"
+
+  linux-pci:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/pci/pci.git"
+
+  mainline:
+    url: 'https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git'
+
+  media-committers:
+    url: 'https://gitlab.freedesktop.org/linux-media/media-committers.git'
+
+  media:
+    url: 'https://git.linuxtv.org/media.git'
+
+  mediatek:
+    url: 'https://git.kernel.org/pub/scm/linux/kernel/git/mediatek/linux.git'
+
+  net-next:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net-next.git"
+
+  netdev-testing:
+    url: "https://github.com/linux-netdev/testing.git"
+
+  next:
+    url: 'https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git'
+
+  omap:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/khilman/linux-omap.git"
+
+  pm:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/rafael/linux-pm.git"
+
+  qcom:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/qcom/linux.git"
+
+  renesas:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/geert/renesas-devel.git"
+
+  riscv:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/riscv/linux.git"
+
+  robh:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/robh/linux.git"
+
+  rppt:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/rppt/memblock.git"
+
+  sashal-next:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/sashal/linus-next.git"
+
+  soc:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/soc/soc.git"
+
+  stable-rc:
+    url: 'https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git'
+
+  stable-rt:
+    url: 'https://git.kernel.org/pub/scm/linux/kernel/git/rt/linux-stable-rt.git'
+
+  stable:
+    url: 'https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git'
+
+  tegra:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/tegra/linux.git"
+
+  thermal:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/thermal/linux.git"
+
+  tip:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git"
+
+  ulfh:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/ulfh/mmc.git"
+
+  vireshk:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/vireshk/linux.git"


### PR DESCRIPTION
Add a yaml file for the community to collaborate on the official KernelCI name/handle for each tree. This will facilitate accessing results information in the dashboard and kci-dev by just supplying the tree_name instead of the full git_url.

This doesn't enforce having an entry for every git_url added to KCIDB. Eg. some origins will use the tree name as the differentiator for a tree that is specific to them, but they submit as different "trees".