### PR TITLE
logspec: Fix crash due _signature_loc not defined

### DIFF
--- a/logspec-worker/logspec_api.py
+++ b/logspec-worker/logspec_api.py
@@ -117,7 +117,7 @@ def get_logspec_errors(parsed_data, parser):
             k: v for k, v in vars(error).items() if v and not k.startswith("_")
         }
         logspec_dict["error"]["signature"] = error._signature
-        logspec_dict["error"]["signature_loc"] = error._signature_loc
+        logspec_dict["error"]["signature_loc"] = getattr(error, '_signature_loc', error._signature)
         logspec_dict["error"]["log_excerpt"] = error._report
         logspec_dict["error"]["signature_fields"] = {
             field: getattr(error, field) for field in error._signature_fields


### PR DESCRIPTION
Error:
```
INFO:root:Processing test maestro:6840e9c3214050d341933cdb
INFO:root:Log ff048710b7985a66a1574b10fbb2e3a4 fetched and saved to cache
INFO:root:Log ID: ff048710b7985a66a1574b10fbb2e3a4
Traceback (most recent call last):
  File "/app/logspec_worker.py", line 521, in <module>
    main()
    ~~~~^^
  File "/app/logspec_worker.py", line 509, in main
    process_tests(cursor, state)
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/app/logspec_worker.py", line 398, in process_tests
    res_nodes, new_status = logspec_process_node(cursor, test, "boot")
                            ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "/app/logspec_worker.py", line 324, in logspec_process_node
    return generate_issues_and_incidents(cursor, node["id"], log_file, kind, node["origin"])
  File "/app/logspec_api.py", line 253, in generate_issues_and_incidents
    error_list, new_status = process_log(log_file, parser, start_state)
                             ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/logspec_api.py", line 218, in process_log
    return get_logspec_errors(parsed_data, parser)
  File "/app/logspec_api.py", line 120, in get_logspec_errors
    logspec_dict["error"]["signature_loc"] = error._signature_loc
                                             ^^^^^^^^^^^^^^^^^^^^
AttributeError: 'ErrorReturnCode' object has no attribute '_signature_loc'. Did you mean: '_signature'?
```

_signature_loc is created in Error class only if _add_signature_loc set to true.