### PR TITLE
Built-in ACME (Let's Encrypt) certificate management

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,10 +1,18 @@
 PG_PASS=kcidb
 PG_URI=postgresql:dbname=kcidb user=kcidb_editor password=kcidb host=db port=5432
 DB_DEFAULT_PASSWORD=kcidb
-CERTBOT_DOMAIN=example.com
 CERTBOT_EMAIL=email@example.com
 JWT_SECRET=your_jwt_secret
-# Uncomment to enable ACME challenge endpoint for certbot webroot mode
+# Built-in ACME (Let's Encrypt) certificate management.
+# Set KCIDB_DOMAINS to a comma-separated list of domains and kcidb-rest will
+# obtain and auto-renew TLS certificates itself (HTTP-01 challenge, requires
+# port 80 to be reachable). CERTBOT_EMAIL above is reused as the ACME account
+# contact; if unset it defaults to bot@kernelci.org.
+# Set ACME_STAGING=1 to use the Let's Encrypt staging environment for testing.
+#KCIDB_DOMAINS=db.example.org
+#ACME_STAGING=1
+# Deprecated: external certbot integration. Use KCIDB_DOMAINS instead.
+#CERTBOT_DOMAIN=example.com
 #ACME_WEBROOT=/var/www/acme-challenge
 POSTGRES_PASSWORD=kcidb
 # Programs will be more talkative if this is set, in production might want to set to 0

--- a/README.md
+++ b/README.md
@@ -81,6 +81,29 @@ PG_URI=postgresql:dbname=kcidb user=kcidb_editor password=kcidb host=db port=543
 JWT_SECRET=your_jwt_secret
 ```
 
+### TLS certificates (built-in ACME)
+
+`kcidb-rest` can obtain and automatically renew its own Let's Encrypt
+certificates. Set `KCIDB_DOMAINS` in `.env` to a comma-separated list of
+domains:
+
+```
+KCIDB_DOMAINS=db.example.org
+CERTBOT_EMAIL=admin@example.org   # ACME account contact (defaults to bot@kernelci.org)
+#ACME_STAGING=1                   # use the Let's Encrypt staging environment for testing
+```
+
+When `KCIDB_DOMAINS` is set, on startup the service validates that every
+domain resolves in DNS, requests a certificate over the HTTP-01 challenge
+(served on port 80), stores it under `/etc/letsencrypt/live/<domain>/`, and
+serves HTTPS on port 443. A background task renews the certificate when it is
+within 30 days of expiry and hot-reloads it without a restart. Both port 80
+and 443 must be published (they already are in `docker-compose.yaml`).
+
+If `KCIDB_DOMAINS` is not set, the service falls back to the deprecated
+external `certbot` integration (`CERTBOT_DOMAIN` / `ACME_WEBROOT`), or serves
+plain HTTP when no TLS is configured.
+
 ## Usage
 
 ### Starting the Services

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,12 +4,16 @@ services:
     image: ghcr.io/kernelci/kcidb-ng/kcidb-rest:latest
     env_file:
       - .env
+    # Built-in ACME: set KCIDB_DOMAINS in .env and kcidb-rest obtains and
+    # auto-renews its own Let's Encrypt certificate into the ./certs volume.
+    # Both port 80 (HTTP-01 challenge) and 443 must be published for this.
     ports:
       - "443:443"
       - "80:80"
     volumes:
       - ./spool:/app/spool
       - ./certs:/etc/letsencrypt
+      # Deprecated: only needed for external certbot in webroot mode.
       # Uncomment to enable ACME challenge for certbot (also set ACME_WEBROOT in .env)
       # - ./acme-challenge:/var/www/acme-challenge
     restart: unless-stopped

--- a/kcidb-restd-rs/Cargo.toml
+++ b/kcidb-restd-rs/Cargo.toml
@@ -14,3 +14,5 @@ serde = "1.0.219"
 serde_json = "1.0.140"
 tokio = { version = "1.44.1", features = ["full"] }
 tower-http = { version = "0.6.2", features = ["limit"] }
+instant-acme = { version = "0.8.5", default-features = false, features = ["aws-lc-rs", "hyper-rustls", "rcgen"] }
+x509-parser = "0.16"

--- a/kcidb-restd-rs/src/main.rs
+++ b/kcidb-restd-rs/src/main.rs
@@ -40,8 +40,14 @@ use serde::{Deserialize, Serialize};
 use std::path::Path;
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
+use tokio::io::AsyncWriteExt;
 use tokio::net::TcpListener;
 use tower_http::limit::RequestBodyLimitLayer;
+use instant_acme::{
+    Account, AccountCredentials, AuthorizationStatus, ChallengeType, Identifier, LetsEncrypt,
+    NewAccount, NewOrder, OrderStatus, RetryPolicy,
+};
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
@@ -84,6 +90,9 @@ struct AppState {
     user_error_counter: AtomicU64,
     start_time: std::time::Instant,
     origin_counters: Mutex<HashMap<String, u64>>,
+    /// HTTP-01 challenge responses (token -> key authorization) published by
+    /// the built-in ACME renewal flow and served on /.well-known/acme-challenge.
+    acme_challenges: Mutex<HashMap<String, String>>,
 }
 
 /// Normalize origin name to be safe for Prometheus labels:
@@ -233,20 +242,29 @@ async fn handle_root() -> impl IntoResponse {
 }
 
 async fn serve_acme_challenge(
+    State(state): State<Arc<AppState>>,
     axum::extract::Path(token): axum::extract::Path<String>,
 ) -> impl IntoResponse {
-    // Check if ACME webroot is configured via environment variable
-    let acme_webroot = match std::env::var("ACME_WEBROOT") {
-        Ok(path) => path,
-        Err(_) => {
-            return (StatusCode::NOT_FOUND, "ACME challenge not configured".to_string());
-        }
-    };
-
     // Validate token contains only safe characters (alphanumeric, dash, underscore)
     if !token.chars().all(|c| c.is_alphanumeric() || c == '-' || c == '_') {
         return (StatusCode::BAD_REQUEST, "Invalid token".to_string());
     }
+
+    // Built-in ACME renewal publishes challenge responses in memory; serve those first.
+    if let Ok(map) = state.acme_challenges.lock()
+        && let Some(key_authorization) = map.get(&token)
+    {
+        return (StatusCode::OK, key_authorization.clone());
+    }
+
+    // TODO: Remove this deprecated feature on next code cleanup.
+    // Fall back to a webroot directory (external certbot in webroot mode).
+    let acme_webroot = match std::env::var("ACME_WEBROOT") {
+        Ok(path) => path,
+        Err(_) => {
+            return (StatusCode::NOT_FOUND, "Challenge not found".to_string());
+        }
+    };
 
     let challenge_path = format!("{}/{}", acme_webroot, token);
     match tokio::fs::read_to_string(&challenge_path).await {
@@ -292,6 +310,7 @@ async fn main() {
         user_error_counter: AtomicU64::new(0),
         start_time: std::time::Instant::now(),
         origin_counters: Mutex::new(HashMap::new()),
+        acme_challenges: Mutex::new(HashMap::new()),
     });
     let tls_key: String;
     let tls_chain: String;
@@ -302,9 +321,102 @@ async fn main() {
         println!("Using JWT secret from command line argument");
     }
 
-    // do we have CERTBOT_DOMAIN? Then certificates are in /certs/live/${CERTBOT_DOMAIN}/
-    // fullchain.pem and privkey.pem
-    if let Ok(certbot_domain) = std::env::var("CERTBOT_DOMAIN") {
+    // Optional built-in ACME (Let's Encrypt) certificate management.
+    // Enabled when KCIDB_DOMAINS is set (comma-separated list of domains).
+    // CERTBOT_EMAIL is reused as the ACME account contact (defaults to
+    // bot@kernelci.org). Set ACME_STAGING=1 to use the Let's Encrypt staging
+    // environment while testing.
+    let acme_domains = acme_domains_from_env();
+    let acme_email = std::env::var("CERTBOT_EMAIL")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "bot@kernelci.org".to_string());
+    let acme_staging = std::env::var("ACME_STAGING")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+
+    if let Some(domains) = &acme_domains {
+        // Validate every domain syntactically before using it.
+        for domain in domains {
+            if !valid_hostname(domain) {
+                eprintln!("Error: invalid domain in KCIDB_DOMAINS: {}", domain);
+                std::process::exit(1);
+            }
+        }
+        // Every domain must resolve in DNS, otherwise ACME HTTP-01 cannot work.
+        for domain in domains {
+            if !domain_resolves(domain).await {
+                eprintln!(
+                    "Error: domain '{}' from KCIDB_DOMAINS does not resolve in DNS",
+                    domain
+                );
+                std::process::exit(1);
+            }
+        }
+        let primary = &domains[0];
+        // Make sure the certbot-style certificate directory exists and is
+        // only accessible by the owner (mode 0700) before we use it.
+        if let Err(e) = ensure_cert_dir(primary) {
+            eprintln!("Error: failed to prepare certificate directory: {}", e);
+            std::process::exit(1);
+        }
+        tls_key = format!("/etc/letsencrypt/live/{}/privkey.pem", primary);
+        tls_chain = format!("/etc/letsencrypt/live/{}/fullchain.pem", primary);
+        println!(
+            "ACME: built-in certificate management enabled for {:?}",
+            domains
+        );
+        if std::env::var("CERTBOT_DOMAIN").is_ok() {
+            println!("ACME: KCIDB_DOMAINS is set, ignoring CERTBOT_DOMAIN");
+        }
+        // The HTTP-01 challenge server on port 80 must be up before issuance.
+        // Bind synchronously here so a failure (e.g. the container lacks
+        // CAP_NET_BIND_SERVICE / is not root) is fatal, instead of being
+        // logged from a background task while we drop into an issuance retry
+        // loop that can never succeed.
+        let challenge_listener = match TcpListener::bind((args.host.as_str(), 80u16)).await {
+            Ok(listener) => {
+                println!("ACME: HTTP-01 challenge server listening on {}:80", args.host);
+                listener
+            }
+            Err(e) => {
+                eprintln!(
+                    "Error: failed to bind ACME challenge server on {}:80: {}",
+                    args.host, e
+                );
+                eprintln!("ACME: certificate issuance/renewal needs port 80 reachable");
+                std::process::exit(1);
+            }
+        };
+        tokio::spawn(run_challenge_server(
+            challenge_listener,
+            app_state.clone(),
+            primary.clone(),
+        ));
+        // The TLS config built below needs a certificate on disk. If we do not
+        // have a valid one, request it now and keep retrying every 30 minutes
+        // (spaced out to stay within Let's Encrypt rate limits) until it works.
+        if cert_needs_renewal(&tls_chain).await {
+            println!("ACME: no valid certificate found, requesting one");
+            let mut attempt = 0;
+            loop {
+                attempt += 1;
+                match obtain_certificate(domains, &acme_email, acme_staging, &app_state).await {
+                    Ok(()) => break,
+                    Err(e) => {
+                        eprintln!("ACME: issuance attempt {} failed: {}", attempt, e);
+                        eprintln!("ACME: retrying in 60 minutes");
+                        tokio::time::sleep(Duration::from_secs(60 * 60)).await;
+                    }
+                }
+            }
+        } else {
+            println!("ACME: existing certificate is still valid");
+        }
+    } else if let Ok(certbot_domain) = std::env::var("CERTBOT_DOMAIN") {
+        // TODO: Remove this deprecated feature on next code cleanup.
+        // External certbot: certificates are in /etc/letsencrypt/live/${CERTBOT_DOMAIN}/
+        // fullchain.pem and privkey.pem
         tls_key = format!("/etc/letsencrypt/live/{}/privkey.pem", certbot_domain);
         tls_chain = format!("/etc/letsencrypt/live/{}/fullchain.pem", certbot_domain);
         // check if the file exists
@@ -396,17 +508,45 @@ async fn main() {
             .route("/health", get(|| async { "OK" }))
             .route("/authtest", get(auth_test))
             .route("/.well-known/acme-challenge/{token}", get(serve_acme_challenge))
-            .with_state(app_state)
+            .with_state(app_state.clone())
             .layer(limit_layer)
             .layer(axum::extract::DefaultBodyLimit::max(512 * 1024 * 1024));
         //let tcp_listener = TcpListener::bind((args.host, args.port)).await.unwrap();
-        let tls_config = match RustlsConfig::from_pem_file(tls_chain, tls_key).await {
+        let tls_config = match RustlsConfig::from_pem_file(&tls_chain, &tls_key).await {
             Ok(config) => config,
             Err(e) => {
                 eprintln!("Failed to load TLS configuration: {}", e);
                 std::process::exit(1);
             }
         };
+        // Background ACME renewal: re-issue before expiry and hot-reload the
+        // running TLS config without restarting the server.
+        if let Some(domains) = acme_domains.clone() {
+            let reload_config = tls_config.clone();
+            let renew_state = app_state.clone();
+            let chain_path = tls_chain.clone();
+            let key_path = tls_key.clone();
+            let email = acme_email.clone();
+            tokio::spawn(async move {
+                loop {
+                    tokio::time::sleep(Duration::from_secs(12 * 3600)).await;
+                    if !cert_needs_renewal(&chain_path).await {
+                        continue;
+                    }
+                    println!("ACME: certificate nearing expiry, renewing");
+                    match obtain_certificate(&domains, &email, acme_staging, &renew_state).await {
+                        Ok(()) => match reload_config
+                            .reload_from_pem_file(&chain_path, &key_path)
+                            .await
+                        {
+                            Ok(()) => println!("ACME: renewed certificate reloaded"),
+                            Err(e) => eprintln!("ACME: failed to reload certificate: {}", e),
+                        },
+                        Err(e) => eprintln!("ACME: renewal failed: {}", e),
+                    }
+                }
+            });
+        }
         let address = format!("{}:{}", args.host, port);
         let addr = match address.parse::<std::net::SocketAddr>() {
             Ok(addr) => addr,
@@ -679,4 +819,416 @@ fn random_string(length: usize) -> String {
         s.push(rng.sample(rand::distr::Alphanumeric) as char);
     }
     s
+}
+
+// ----------------------------------------------------------------------------
+// Optional built-in ACME (Let's Encrypt) certificate management.
+// Active only when the KCIDB_DOMAINS environment variable is set.
+// ----------------------------------------------------------------------------
+
+type AcmeResult<T> = Result<T, Box<dyn std::error::Error + Send + Sync>>;
+
+/// Parse the optional KCIDB_DOMAINS environment variable into a list of domains.
+/// Returns None when unset or empty, which disables built-in ACME.
+fn acme_domains_from_env() -> Option<Vec<String>> {
+    let raw = std::env::var("KCIDB_DOMAINS").ok()?;
+    let domains: Vec<String> = raw
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
+    if domains.is_empty() {
+        None
+    } else {
+        Some(domains)
+    }
+}
+
+/// Minimal hostname validation for domains handed to the ACME client.
+fn valid_hostname(domain: &str) -> bool {
+    !domain.is_empty()
+        && domain.len() <= 253
+        && domain.contains('.')
+        && !domain.starts_with('.')
+        && !domain.starts_with('-')
+        && !domain.ends_with('.')
+        && domain
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '.')
+}
+
+/// Check that `domain` resolves to at least one IP address via DNS.
+/// ACME HTTP-01 validation cannot succeed for a domain that does not resolve.
+async fn domain_resolves(domain: &str) -> bool {
+    match tokio::net::lookup_host((domain, 0u16)).await {
+        Ok(mut addrs) => addrs.next().is_some(),
+        Err(_) => false,
+    }
+}
+
+/// Ensure the certbot-style certificate directory for `primary` exists and is
+/// only accessible by the owner (mode 0700), since private keys live there.
+/// Returns the path of the live directory.
+fn ensure_cert_dir(primary: &str) -> std::io::Result<String> {
+    let live_dir = format!("/etc/letsencrypt/live/{}", primary);
+    if !Path::new(&live_dir).exists() {
+        std::fs::create_dir_all(&live_dir)?;
+        println!("ACME: created certificate directory {}", live_dir);
+    }
+    #[cfg(target_family = "unix")]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        // Best-effort on the mount root; strict on the directories we manage.
+        let _ = std::fs::set_permissions(
+            "/etc/letsencrypt",
+            std::fs::Permissions::from_mode(0o700),
+        );
+        for dir in ["/etc/letsencrypt/live", live_dir.as_str()] {
+            std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700))?;
+        }
+    }
+    Ok(live_dir)
+}
+
+/// Returns true if the certificate at `cert_path` is missing, unreadable,
+/// already expired, or expires within the next 30 days.
+async fn cert_needs_renewal(cert_path: &str) -> bool {
+    let data = match tokio::fs::read(cert_path).await {
+        Ok(data) => data,
+        Err(_) => return true,
+    };
+    match x509_parser::pem::parse_x509_pem(&data) {
+        Ok((_, pem)) => match pem.parse_x509() {
+            Ok(cert) => match cert.validity().time_to_expiration() {
+                Some(remaining) => remaining.whole_days() < 30,
+                None => true,
+            },
+            Err(_) => true,
+        },
+        Err(_) => true,
+    }
+}
+
+/// Serve the ACME HTTP-01 challenge endpoint on port 80 and redirect every
+/// other request to HTTPS. Runs as a background task when built-in ACME is on.
+/// The port-80 `listener` is bound by the caller so that a bind failure is a
+/// hard startup error rather than a silently logged background-task failure.
+/// `canonical_domain` is the primary KCIDB_DOMAINS entry; HTTPS redirects are
+/// built from it rather than the request's Host header.
+async fn run_challenge_server(
+    listener: TcpListener,
+    state: Arc<AppState>,
+    canonical_domain: String,
+) {
+    let app = Router::new()
+        .route(
+            "/.well-known/acme-challenge/{token}",
+            get(serve_acme_challenge),
+        )
+        .route("/health", get(|| async { "OK" }))
+        .fallback(move |uri: axum::http::Uri| {
+            redirect_to_https(canonical_domain.clone(), uri)
+        })
+        .with_state(state);
+    if let Err(e) = axum::serve(listener, app).await {
+        eprintln!("ACME: challenge server stopped: {}", e);
+    }
+}
+
+/// Redirect a plain HTTP request to its HTTPS equivalent.
+///
+/// The Location is built from `canonical_domain` (the configured primary
+/// domain), not the request's Host header. The Host header is attacker-
+/// controlled, so trusting it would allow open-redirect abuse and can also
+/// produce malformed targets such as `https://example.com:80/...` when the
+/// client sends an explicit `:80` port.
+async fn redirect_to_https(canonical_domain: String, uri: axum::http::Uri) -> impl IntoResponse {
+    let path = uri.path_and_query().map(|pq| pq.as_str()).unwrap_or("/");
+    axum::response::Redirect::permanent(&format!("https://{}{}", canonical_domain, path))
+}
+
+/// Ensure /etc/letsencrypt exists and is owner-only, since both the ACME
+/// account credentials and the certificate private keys are stored beneath it.
+fn ensure_letsencrypt_dir() -> std::io::Result<()> {
+    let root = "/etc/letsencrypt";
+    if !Path::new(root).exists() {
+        std::fs::create_dir_all(root)?;
+    }
+    #[cfg(target_family = "unix")]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        // Best-effort: the mount root may be owned by another uid.
+        let _ = std::fs::set_permissions(root, std::fs::Permissions::from_mode(0o700));
+    }
+    Ok(())
+}
+
+/// Atomically write `contents` to `path` with permission `mode`.
+///
+/// Certificate and key material must never be observed half-written: a
+/// concurrent TLS reload (or any external reader sharing the volume mount)
+/// that picks up a truncated PEM gets an unusable file. A plain
+/// `tokio::fs::write` truncates the target up front and streams bytes into it,
+/// so both a crash mid-write and a concurrent read expose a partial file.
+///
+/// Instead we write into a uniquely named temp file in the *same directory*
+/// (so the final `rename` stays on one filesystem and is therefore atomic),
+/// fsync it so the bytes are durable, set `mode` *before* the rename so the
+/// target never appears with looser permissions, then rename it into place.
+/// rename(2) is atomic, so a reader of `path` always sees either the complete
+/// previous file or the complete new one. A crash leaves only a stale temp
+/// file; `path` keeps its previous valid contents (or stays absent).
+async fn atomic_write(path: &str, contents: &[u8], mode: u32) -> std::io::Result<()> {
+    let target = Path::new(path);
+    let dir = target.parent().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("atomic_write: path has no parent directory: {}", path),
+        )
+    })?;
+    let file_name = target.file_name().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("atomic_write: path has no file name: {}", path),
+        )
+    })?;
+
+    // Temp name is dotted (hidden) and randomized so a crash leaves something
+    // obviously transient behind and concurrent writers cannot collide.
+    let tmp_path = dir.join(format!(
+        ".{}.tmp.{}",
+        file_name.to_string_lossy(),
+        random_string(12)
+    ));
+
+    // Write + flush + fsync the temp file. On any failure, remove the temp
+    // file so we never accumulate stale fragments next to the real cert.
+    let write_result = async {
+        let mut file = tokio::fs::File::create(&tmp_path).await?;
+        file.write_all(contents).await?;
+        file.flush().await?;
+        // Force the bytes to disk before the rename, otherwise a crash could
+        // leave the rename committed but the file's contents still empty.
+        file.sync_all().await?;
+        Ok::<(), std::io::Error>(())
+    }
+    .await;
+    if let Err(e) = write_result {
+        let _ = tokio::fs::remove_file(&tmp_path).await;
+        return Err(e);
+    }
+
+    // Apply the requested mode while the file still has its temporary name,
+    // so `path` is never visible with default (umask-derived) permissions.
+    #[cfg(target_family = "unix")]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Err(e) =
+            tokio::fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(mode)).await
+        {
+            let _ = tokio::fs::remove_file(&tmp_path).await;
+            return Err(e);
+        }
+    }
+    #[cfg(not(target_family = "unix"))]
+    let _ = mode;
+
+    // The atomic swap. On failure, drop the temp file rather than leak it.
+    if let Err(e) = tokio::fs::rename(&tmp_path, target).await {
+        let _ = tokio::fs::remove_file(&tmp_path).await;
+        return Err(e);
+    }
+
+    // Best-effort: fsync the directory so the rename itself survives a crash.
+    // Not all platforms allow opening a directory as a file; ignore failures.
+    if let Ok(dir_handle) = tokio::fs::File::open(dir).await {
+        let _ = dir_handle.sync_all().await;
+    }
+
+    Ok(())
+}
+
+/// Path of the persisted ACME account credentials. Kept inside /etc/letsencrypt
+/// so it survives container restarts via the same volume mount as the certs.
+/// Staging and production accounts live on different ACME servers and on
+/// distinct key pairs, so each environment gets its own file.
+fn acme_account_path(staging: bool) -> &'static str {
+    if staging {
+        "/etc/letsencrypt/acme-account-staging.json"
+    } else {
+        "/etc/letsencrypt/acme-account.json"
+    }
+}
+
+/// Restore a previously persisted ACME account, or register a fresh one and
+/// persist its credentials. Reusing the account across issuances and renewals
+/// avoids registering a new account every time, which would churn accounts and
+/// can trip ACME provider rate limits.
+///
+/// instant-acme's `Account::builder()` sets up its own HTTPS client and crypto
+/// provider; both `create` and `from_credentials` go through the same builder.
+async fn load_or_create_account(
+    email: &str,
+    staging: bool,
+    directory_url: &str,
+) -> AcmeResult<Account> {
+    let path = acme_account_path(staging);
+
+    // Try to restore an existing account from persisted credentials first.
+    match tokio::fs::read(path).await {
+        Ok(data) => match serde_json::from_slice::<AccountCredentials>(&data) {
+            Ok(credentials) => match Account::builder()?.from_credentials(credentials).await {
+                Ok(account) => {
+                    println!("ACME: reusing persisted account credentials from {}", path);
+                    return Ok(account);
+                }
+                Err(e) => eprintln!(
+                    "ACME: stored account in {} is unusable ({}); registering a new account",
+                    path, e
+                ),
+            },
+            Err(e) => eprintln!(
+                "ACME: could not parse account credentials in {} ({}); registering a new account",
+                path, e
+            ),
+        },
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            println!("ACME: no persisted account at {}; registering a new account", path);
+        }
+        Err(e) => eprintln!(
+            "ACME: could not read account credentials at {} ({}); registering a new account",
+            path, e
+        ),
+    }
+
+    // No usable credentials: register a new account and persist it.
+    let contacts = [format!("mailto:{}", email)];
+    let contact_refs: Vec<&str> = contacts.iter().map(String::as_str).collect();
+    let (account, credentials) = Account::builder()?
+        .create(
+            &NewAccount {
+                contact: &contact_refs,
+                terms_of_service_agreed: true,
+                only_return_existing: false,
+            },
+            directory_url.to_owned(),
+            None,
+        )
+        .await?;
+
+    // Persist the credentials so future renewals reuse this account. Failure
+    // here is non-fatal: issuance can still proceed with the in-memory account.
+    match serde_json::to_vec(&credentials) {
+        Ok(serialized) => {
+            if let Err(e) = ensure_letsencrypt_dir() {
+                eprintln!("ACME: could not prepare {} ({}); account not persisted",
+                    "/etc/letsencrypt", e);
+            } else if let Err(e) = atomic_write(path, &serialized, 0o600).await {
+                // The file holds the account private key, so it is written
+                // atomically with 0600 permissions already in place.
+                eprintln!("ACME: failed to persist account credentials to {}: {}", path, e);
+            } else {
+                println!("ACME: registered new account, credentials saved to {}", path);
+            }
+        }
+        Err(e) => eprintln!("ACME: failed to serialize account credentials: {}", e),
+    }
+
+    Ok(account)
+}
+
+/// Obtain (or renew) a certificate for `domains` via the ACME HTTP-01 flow and
+/// write it into /etc/letsencrypt/live/<primary-domain>/ in the certbot layout.
+async fn obtain_certificate(
+    domains: &[String],
+    email: &str,
+    staging: bool,
+    state: &Arc<AppState>,
+) -> AcmeResult<()> {
+    let directory_url = if staging {
+        LetsEncrypt::Staging.url()
+    } else {
+        LetsEncrypt::Production.url()
+    };
+    println!(
+        "ACME: requesting certificate for {:?} ({} environment)",
+        domains,
+        if staging { "staging" } else { "production" }
+    );
+
+    // Reuse a persisted ACME account if one exists, otherwise register a new
+    // one and persist it. This keeps a single stable account across renewals
+    // instead of churning a new account on every issuance.
+    let account = load_or_create_account(email, staging, directory_url).await?;
+
+    // Create the order covering every requested domain.
+    let identifiers: Vec<Identifier> =
+        domains.iter().map(|d| Identifier::Dns(d.clone())).collect();
+    let mut order = account.new_order(&NewOrder::new(&identifiers)).await?;
+
+    // Publish an HTTP-01 response for each pending authorization.
+    let mut tokens: Vec<String> = Vec::new();
+    let mut authorizations = order.authorizations();
+    while let Some(result) = authorizations.next().await {
+        let mut authz = result?;
+        match authz.status {
+            AuthorizationStatus::Pending => {}
+            AuthorizationStatus::Valid => continue,
+            ref other => {
+                return Err(format!("unexpected authorization status: {:?}", other).into());
+            }
+        }
+        let mut challenge = authz
+            .challenge(ChallengeType::Http01)
+            .ok_or("ACME server did not offer an HTTP-01 challenge")?;
+        let token = challenge.token.clone();
+        let key_authorization = challenge.key_authorization().as_str().to_string();
+        if let Ok(mut map) = state.acme_challenges.lock() {
+            map.insert(token.clone(), key_authorization);
+        }
+        tokens.push(token);
+        challenge.set_ready().await?;
+    }
+
+    // Wait for validation, then finalize and download the certificate.
+    // (`authorizations` borrows `order`; its borrow ends with the loop above.)
+    let outcome = async {
+        let status = order.poll_ready(&RetryPolicy::default()).await?;
+        if status != OrderStatus::Ready {
+            return Err(format!("ACME order did not become ready: {:?}", status).into());
+        }
+        let private_key_pem = order.finalize().await?;
+        let cert_chain_pem = order.poll_certificate(&RetryPolicy::default()).await?;
+        Ok::<_, Box<dyn std::error::Error + Send + Sync>>((private_key_pem, cert_chain_pem))
+    }
+    .await;
+
+    // Drop the published challenge responses whether or not issuance succeeded.
+    if let Ok(mut map) = state.acme_challenges.lock() {
+        for token in &tokens {
+            map.remove(token);
+        }
+    }
+
+    let (private_key_pem, cert_chain_pem) = outcome?;
+
+    // Persist in the certbot-compatible layout so existing volume mounts work.
+    let live_dir = ensure_cert_dir(&domains[0])?;
+    let key_path = format!("{}/privkey.pem", live_dir);
+    let chain_path = format!("{}/fullchain.pem", live_dir);
+    // Write both files atomically so a concurrent TLS reload never reads a
+    // half-written PEM. privkey.pem holds the private key (owner-only, 0600);
+    // fullchain.pem is public material but uses the same atomic path.
+    //
+    // TODO: each file is individually atomic, but the *pair* is not. A reader
+    // that runs between these two writes can pick up the new privkey.pem with
+    // the old fullchain.pem (or vice versa). Within this process that is safe
+    // (reload_from_pem_file runs only after both writes return), but an
+    // external consumer sharing the /etc/letsencrypt volume could catch the
+    // gap. To make the pair atomic, write into a fresh live/<domain>.<random>/
+    // directory and rename the directory into place (or symlink-swap it).
+    atomic_write(&key_path, private_key_pem.as_bytes(), 0o600).await?;
+    atomic_write(&chain_path, cert_chain_pem.as_bytes(), 0o644).await?;
+    println!("ACME: certificate stored in {}", live_dir);
+    Ok(())
 }


### PR DESCRIPTION
Just set KCIDB_DOMAINS and rest will be done automagically. As precautions, on cert retry timeout is 1 hour, so we wont get banned, due some intermittent failures.
Some deprecated code need cleanup later, after migrating all systems.