### PR TITLE
ci: bump GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,20 +22,20 @@ jobs:
             dockerfile: Dockerfile.logspec-worker
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ${{ matrix.dockerfile }}
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Validate docker-compose syntax
         run: |


### PR DESCRIPTION
Workflow runs emit a deprecation warning:

  Node.js 20 actions are deprecated. The following actions are running
  on Node.js 20: actions/checkout@v4, docker/build-push-action@v6,
  docker/login-action@v3, docker/setup-buildx-action@v3
  ... Node.js 20 will be removed from the runner on September 16th, 2026.

Bump all four to their current majors:

  actions/checkout            v4 -> v7
  docker/setup-buildx-action  v3 -> v4
  docker/login-action         v3 -> v4
  docker/build-push-action    v6 -> v7

The docker/* major bumps are solely the Node 24 runtime switch with no input changes. checkout v5..v7 additionally moves credentials to a separate file, converts to ESM, and blocks fork PR checkout under pull_request_target/workflow_run - none of which this workflow uses, so all four are drop-in.

appleboy/ssh-action@v1 and appleboy/scp-action@v1 are already current and are Docker actions, so they are unaffected by the Node deprecation.